### PR TITLE
Add attribution and "In Memoriam" section for Carolyn Van Slyck

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -55,3 +55,19 @@ func CustomInstallTool() error {
 	return shx.Command("go", "run", "bootstrap.go").In(src).RunE()
 }
 ```
+
+## Attribution
+
+This project is a fork of https://github.com/carolynvs/magex at
+[0b6a1c6](https://github.com/carolynvs/magex/tree/0b6a1c6d5cba42cbad741c93546e99837b1c1fb9).
+
+### In Memoriam
+
+[Carolyn Van Slyck](https://github.com/carolynvs) was the original maintainer
+of this project and is no longer with us.
+She was a fan of [`mage`](https://magefile.org/) and I'd like to do my small
+part by continuing her extensions project.
+
+If you've had the opportunity to work with Carolyn and would like to leave a
+message in her memory, please take a moment to do so on her CNCF
+[memorial page](https://github.com/cncf/memorials/blob/main/carolyn-van-slyck.md).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Magefile Extensions
 
-![test](https://github.com/carolynvs/magex/workflows/test/badge.svg)
+![test](https://github.com/uwu-tools/magex/workflows/test/badge.svg)
 
 This library provides helper methods to use with [mage](https://magefile.org).
 
 Below is a sample of the type of helpers available. Full examples and
-documentation is on [godoc](https://godoc.org/github.com/carolynvs/magex).
+documentation is on [godoc](https://godoc.org/github.com/uwu-tools/magex).
 
 ```go
 // +build mage
@@ -13,8 +13,8 @@ documentation is on [godoc](https://godoc.org/github.com/carolynvs/magex).
 package main
 
 import (
-	"github.com/carolynvs/magex/pkg"
-	"github.com/carolynvs/magex/shx"
+	"github.com/uwu-tools/magex/pkg"
+	"github.com/uwu-tools/magex/shx"
 )
 
 // Check if packr2 is in the bin/ directory and is at least v2.

--- a/ci/build_provider_example_test.go
+++ b/ci/build_provider_example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/carolynvs/magex/ci"
+	"github.com/uwu-tools/magex/ci"
 )
 
 func TestExampleDetectBuildProvider(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/carolynvs/magex
+module github.com/uwu-tools/magex
 
 go 1.19
 
@@ -7,4 +7,19 @@ require (
 	github.com/magefile/mage v1.13.0
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/stretchr/testify v1.7.1
+)
+
+require (
+	github.com/andybalholm/brotli v1.0.1 // indirect
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
+	github.com/golang/snappy v0.0.2 // indirect
+	github.com/klauspost/compress v1.11.4 // indirect
+	github.com/klauspost/pgzip v1.2.5 // indirect
+	github.com/nwaples/rardecode v1.1.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/ulikunitz/xz v0.5.9 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/carolynvs/magex
 
-go 1.15
+go 1.19
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1

--- a/magefile.go
+++ b/magefile.go
@@ -8,10 +8,10 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/carolynvs/magex/pkg"
-	"github.com/carolynvs/magex/shx"
-	"github.com/carolynvs/magex/xplat"
 	"github.com/magefile/mage/mg"
+	"github.com/uwu-tools/magex/pkg"
+	"github.com/uwu-tools/magex/shx"
+	"github.com/uwu-tools/magex/xplat"
 )
 
 var Default = Test

--- a/pkg/archive/install.go
+++ b/pkg/archive/install.go
@@ -7,10 +7,10 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/carolynvs/magex/pkg/downloads"
-	"github.com/carolynvs/magex/xplat"
 	"github.com/mholt/archiver/v3"
 	_ "github.com/mholt/archiver/v3"
+	"github.com/uwu-tools/magex/pkg/downloads"
+	"github.com/uwu-tools/magex/xplat"
 )
 
 // DownloadArchiveOptions are the set of options available for DownloadToGopathBin.

--- a/pkg/archive/install_example_test.go
+++ b/pkg/archive/install_example_test.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"testing"
 
-	"github.com/carolynvs/magex/pkg/archive"
-	"github.com/carolynvs/magex/pkg/downloads"
-	"github.com/carolynvs/magex/pkg/gopath"
+	"github.com/uwu-tools/magex/pkg/archive"
+	"github.com/uwu-tools/magex/pkg/downloads"
+	"github.com/uwu-tools/magex/pkg/gopath"
 )
 
 func TestExampleDownloadToGopathBin(t *testing.T) {

--- a/pkg/archive/install_test.go
+++ b/pkg/archive/install_test.go
@@ -6,11 +6,11 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/carolynvs/magex/pkg/downloads"
-	"github.com/carolynvs/magex/pkg/gopath"
-	"github.com/carolynvs/magex/xplat"
 	"github.com/magefile/mage/mg"
 	"github.com/stretchr/testify/require"
+	"github.com/uwu-tools/magex/pkg/downloads"
+	"github.com/uwu-tools/magex/pkg/gopath"
+	"github.com/uwu-tools/magex/xplat"
 )
 
 func TestDownloadArchiveToGopathBin_OsReplacement(t *testing.T) {

--- a/pkg/downloads/download.go
+++ b/pkg/downloads/download.go
@@ -12,9 +12,9 @@ import (
 	"runtime"
 	"text/template"
 
-	"github.com/carolynvs/magex/pkg/gopath"
-	"github.com/carolynvs/magex/shx"
-	"github.com/carolynvs/magex/xplat"
+	"github.com/uwu-tools/magex/pkg/gopath"
+	"github.com/uwu-tools/magex/shx"
+	"github.com/uwu-tools/magex/xplat"
 )
 
 // PostDownloadHook is the handler called after downloading a file, which returns the absolute path to the binary.

--- a/pkg/downloads/download_test.go
+++ b/pkg/downloads/download_test.go
@@ -1,10 +1,10 @@
 package downloads
 
 import (
-	"github.com/carolynvs/magex/pkg/gopath"
-	"github.com/carolynvs/magex/xplat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uwu-tools/magex/pkg/gopath"
+	"github.com/uwu-tools/magex/xplat"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"

--- a/pkg/gopath/gopath.go
+++ b/pkg/gopath/gopath.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/carolynvs/magex/xplat"
+	"github.com/uwu-tools/magex/xplat"
 )
 
 // EnsureGopathBin ensures that GOPATH/bin exists and is in PATH.

--- a/pkg/install.go
+++ b/pkg/install.go
@@ -10,12 +10,12 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/carolynvs/magex/pkg/gopath"
+	"github.com/uwu-tools/magex/pkg/gopath"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/carolynvs/magex/pkg/downloads"
-	"github.com/carolynvs/magex/shx"
-	"github.com/carolynvs/magex/xplat"
+	"github.com/uwu-tools/magex/pkg/downloads"
+	"github.com/uwu-tools/magex/shx"
+	"github.com/uwu-tools/magex/xplat"
 )
 
 // EnsureMage checks if mage is installed, and installs it if needed.

--- a/pkg/install_example_test.go
+++ b/pkg/install_example_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/carolynvs/magex/pkg"
-	"github.com/carolynvs/magex/pkg/gopath"
+	"github.com/uwu-tools/magex/pkg"
+	"github.com/uwu-tools/magex/pkg/gopath"
 )
 
 func TestExampleEnsureMage(t *testing.T) {

--- a/pkg/install_test.go
+++ b/pkg/install_test.go
@@ -6,11 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/carolynvs/magex/pkg/gopath"
-	"github.com/carolynvs/magex/xplat"
 	"github.com/magefile/mage/mg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uwu-tools/magex/pkg/gopath"
+	"github.com/uwu-tools/magex/xplat"
 )
 
 func TestDownloadToGopathBin(t *testing.T) {

--- a/shx/copy_example_test.go
+++ b/shx/copy_example_test.go
@@ -1,7 +1,7 @@
 package shx_test
 
 import (
-	"github.com/carolynvs/magex/shx"
+	"github.com/uwu-tools/magex/shx"
 )
 
 func ExampleCopy() {

--- a/shx/move_example_test.go
+++ b/shx/move_example_test.go
@@ -1,6 +1,6 @@
 package shx_test
 
-import "github.com/carolynvs/magex/shx"
+import "github.com/uwu-tools/magex/shx"
 
 func ExampleMove() {
 	// Move a file from the current directory into TEMP

--- a/shx/prepared_command.go
+++ b/shx/prepared_command.go
@@ -9,9 +9,9 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/carolynvs/magex/mgx"
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
+	"github.com/uwu-tools/magex/mgx"
 )
 
 type PreparedCommand struct {
@@ -71,7 +71,8 @@ func (c PreparedCommand) CollapseArgs() PreparedCommand {
 // Env defines additional environment variables for the command.
 // All ambient environment variables are included by default.
 // Example:
-//  c.Env("X=1", "Y=2")
+//
+//	c.Env("X=1", "Y=2")
 func (c PreparedCommand) Env(vars ...string) PreparedCommand {
 	for _, v := range vars {
 		c.Cmd.Env = append(c.Cmd.Env, v)

--- a/shx/prepared_command_example_test.go
+++ b/shx/prepared_command_example_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"path/filepath"
 
-	"github.com/carolynvs/magex/shx"
+	"github.com/uwu-tools/magex/shx"
 )
 
 func ExamplePreparedCommand_RunV() {

--- a/shx/prepared_command_test.go
+++ b/shx/prepared_command_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/carolynvs/magex/shx"
 	"github.com/magefile/mage/mg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uwu-tools/magex/shx"
 )
 
 func TestPreparedCommand_Run(t *testing.T) {

--- a/shx/shx_example_test.go
+++ b/shx/shx_example_test.go
@@ -3,7 +3,7 @@ package shx_test
 import (
 	"log"
 
-	"github.com/carolynvs/magex/shx"
+	"github.com/uwu-tools/magex/shx"
 )
 
 func ExampleRun() {


### PR DESCRIPTION
This project is a fork of https://github.com/uwu-tools/magex at
[0b6a1c6](https://github.com/uwu-tools/magex/tree/0b6a1c6d5cba42cbad741c93546e99837b1c1fb9).

[Carolyn Van Slyck](https://github.com/carolynvs) was the original maintainer
of this project and is no longer with us.
She was a fan of [`mage`](https://magefile.org/) and I'd like to do my small
part by continuing her extensions project.

If you've had the opportunity to work with Carolyn and would like to leave a
message in her memory, please take a moment to do so on her CNCF
[memorial page](https://github.com/cncf/memorials/blob/main/carolyn-van-slyck.md).

Also in this patchset:
- .github: Add dependabot configuration
- go.mod: Update go module to go1.19
- Update module references to uwu-tools/magex

Signed-off-by: Stephen Augustus <foo@auggie.dev>